### PR TITLE
It's not much, but it helps

### DIFF
--- a/Source/content_script.js
+++ b/Source/content_script.js
@@ -7,7 +7,7 @@ function walk(node)
 	
 	var child, next;
 	
-	if (['input', 'textarea'].indexOf(node.tagName.toLowerCase()) > -1
+	if (node.tagName.toLowerCase() == 'input' || node.tagName.toLowerCase() == 'textarea'
 	    || node.classList.indexOf('ace_editor') > -1) {
 		break;
 	}

--- a/Source/content_script.js
+++ b/Source/content_script.js
@@ -6,6 +6,11 @@ function walk(node)
 	// http://is.gd/mwZp7E
 	
 	var child, next;
+	
+	if (['input', 'textarea'].indexOf(node.tagName.toLowerCase()) > -1
+	    || node.classList.indexOf('ace_editor') > -1) {
+		break;
+	}
 
 	switch ( node.nodeType )  
 	{


### PR DESCRIPTION
`content_script.js` will now skip over all `<input>`s and `<textarea>`s, as well as any Ace Editors on the page.

This will help with online editors, so that the script won't replace 'The Cloud' when loading a file to edit.

A couple examples of when this might help:
* cf9198c
* 7f5287d

Also,
![The Cloud to Butt Plus Chrome Extension page](http://i.imgur.com/gMrobyR.png)