### PR TITLE
Update source to work better with lazy-loading sites

### DIFF
--- a/Source/content_script.js
+++ b/Source/content_script.js
@@ -1,4 +1,6 @@
-walk(document.body);
+document.addEventListener("DOMNodeInserted", function(e) {
+  walk(document.body);
+}, false);
 
 function walk(node) 
 {


### PR DESCRIPTION
A site such as Facebook, which has infinite scroll, will not change new instances of "the cloud" when the user scrolls down and more posts are added to the newsfeed. By adding an event listener, we can also target such instances and thus get even closer to the dream of true 100% aerosol-rectal conversion.